### PR TITLE
Making compiler more robust to path formats

### DIFF
--- a/WootzJs.Compiler/Compiler.cs
+++ b/WootzJs.Compiler/Compiler.cs
@@ -87,7 +87,7 @@ namespace WootzJs.Compiler
                         var output = result.Item1;
                         var solution = result.Item2;
                         var solutionName = fileInfo.Name.Substring(0, fileInfo.Name.Length - ".sln".Length);
-                        File.WriteAllText(fileFolder + "\\" + outputFolder + solutionName + ".js", output);
+                        File.WriteAllText(Path.Combine(fileFolder, outputFolder, solutionName + ".js"), output);
                     }
                     else
                     {
@@ -96,7 +96,7 @@ namespace WootzJs.Compiler
                         var project = result.Item2;
                         var projectName = project.AssemblyName;
 
-                        File.WriteAllText(fileFolder + "\\" + outputFolder + projectName + ".js", output);
+                        File.WriteAllText(Path.Combine(fileFolder, outputFolder, projectName + ".js"), output);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
This was just a fix to make the compiler less sensitive to whether you input a folder with or without a trailing/leading slash. I fixed this because I ran into this as a problem when trying to get WootzJs to work. 
