### PR TITLE
Conditional compile

### DIFF
--- a/WootzJs.Compiler/Compiler.cs
+++ b/WootzJs.Compiler/Compiler.cs
@@ -43,11 +43,13 @@ namespace WootzJs.Compiler
 
         private string mscorlib;
         private string[] defines;
+		private Dictionary<string, string> msbuildProperties;
 
-        public Compiler(string mscorlib, string[] defines)
+        public Compiler(string mscorlib, string[] defines, Dictionary<string, string> msbuildProperties)
         {
             this.mscorlib = mscorlib;
             this.defines = defines;
+			this.msbuildProperties = msbuildProperties;
         }
 
         public static void Main(string[] args)
@@ -70,6 +72,10 @@ namespace WootzJs.Compiler
             var define = namedArguments.Get("define");
             var defines = define == null ? new string[0] : define.Split(',');
 
+			var msbuildProperties = new Dictionary<string, string>() {
+				{  "WootzJs", "true" } // predefine reliable conditional property for all consumers
+			};
+
             if (performanceFile != null)
             {
                 Profiler.Output = new StreamWriter(performanceFile);
@@ -83,7 +89,7 @@ namespace WootzJs.Compiler
                 {
                     if (fileInfo.Extension.Equals(".sln", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        var result = await Profiler.Time("Total Time", async () => await new Compiler(mscorlib, defines).CompileSolution(projectOrSolutionFile));                    
+                        var result = await Profiler.Time("Total Time", async () => await new Compiler(mscorlib, defines, msbuildProperties).CompileSolution(projectOrSolutionFile));                    
                         var output = result.Item1;
                         var solution = result.Item2;
                         var solutionName = fileInfo.Name.Substring(0, fileInfo.Name.Length - ".sln".Length);
@@ -91,7 +97,7 @@ namespace WootzJs.Compiler
                     }
                     else
                     {
-                        var result = await Profiler.Time("Total Time", async () => await new Compiler(mscorlib, defines).CompileProject(projectOrSolutionFile));
+                        var result = await Profiler.Time("Total Time", async () => await new Compiler(mscorlib, defines, msbuildProperties).CompileProject(projectOrSolutionFile));
                         var output = result.Item1;
                         var project = result.Item2;
                         var projectName = project.AssemblyName;
@@ -111,7 +117,7 @@ namespace WootzJs.Compiler
 
         public async Task<Tuple<string, Solution>> CompileSolution(string solutionFile)
         {
-//            var solution = await Profiler.Time("Loading Project", async () => await MSBuildWorkspace.Create().OpenSolutionAsync(solutionFile));
+//            var solution = await Profiler.Time("Loading Project", async () => await MSBuildWorkspace.Create(this.msbuildProperties).OpenSolutionAsync(solutionFile));
             var jsCompilationUnit = new JsCompilationUnit { UseStrict = true };
 
             // Since we have all the types required by the solution, we can keep track of which symbols are used and which
@@ -120,7 +126,7 @@ namespace WootzJs.Compiler
             RemoveUnusedSymbols = true;
 
             var projectFiles = FileUtils.GetProjectFiles(solutionFile);
-            var workspace = MSBuildWorkspace.Create();
+            var workspace = MSBuildWorkspace.Create(this.msbuildProperties);
             var solution = await Profiler.Time("Loading Solution", async () =>
             {
                 string mscorlib = this.mscorlib;
@@ -206,7 +212,7 @@ namespace WootzJs.Compiler
 //                File.SetLastWriteTime(projectUserFile, DateTime.Now);
 
             var jsCompilationUnit = new JsCompilationUnit { UseStrict = true };
-            var workspace = MSBuildWorkspace.Create();
+            var workspace = MSBuildWorkspace.Create(this.msbuildProperties);
             var project = await Profiler.Time("Loading Project", async () =>
             {
                 string mscorlib = this.mscorlib;


### PR DESCRIPTION
We have to be able to compile the same library for C# and JavaScript. That means being able to conditionally use the real mscorlib, or the JS one. Adding this MSBuild property meant we could do this:

```
  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'JS|AnyCPU'">
...
    <WootzJs>true</WootzJs>
  </PropertyGroup>
...
  <ItemGroup Condition=" '$(WootzJs)' == '' ">
    <Reference Include="System" />
    <Reference Include="System.Core" />
    <Reference Include="System.Xml.Linq" />
    <Reference Include="System.Data.DataSetExtensions" />
    <Reference Include="Microsoft.CSharp" />
    <Reference Include="System.Data" />
    <Reference Include="System.Net.Http" />
    <Reference Include="System.Xml" />
  </ItemGroup>
...
  <Import Project="..\packages\WootzJs.Compiler.1.0.2\tools\build\WootzJs.targets" Condition=" '$(WootzJs)' != '' " />
```

 Which means it'll still compile to C# when you're either using the normal build configuration (Debug or Release). When we want to verify it compiles with JavaScript, we switch to the JS build configuration. And because the WootzJs compiler sets the WootzJs MSBuild property as well, it ensures Roslyn is seeing the correct version of the csproj. 

This won't break existing workflows - people don't have to use this condition at all, and it'll still work as it did previously. 
